### PR TITLE
Persistent cookie consent choice

### DIFF
--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -9,7 +9,12 @@
      $('.scrollspy').scrollSpy();
      $('.tap-target').tapTarget('open');
 
+     if (localStorage.getItem('cookieconsent') === 'true') {
+       $('#cookies').hide()
+     }
+
      jQuery('#cookies').on('click', function(event) {
+            localStorage.setItem('cookieconsent', 'true')
             jQuery('#cookies').toggle('hide');
        });
 


### PR DESCRIPTION
Stores in localstorage when a user dismisses the cookie message, so that it does not return at refresh.