### PR TITLE
Reinstate front matter for scss

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,3 +1,6 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
 // Syntax highlighting sass properties and inclusion
 $base-font-size: 1em;
 $spacing-unit:     30px !default;


### PR DESCRIPTION
Front matter for main.scss file restored, jekyll then properly renders the main.css file as per:
https://jekyllrb.com/docs/assets/

fixes: #20