### PR TITLE
Hotfix/remove ignore files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,9 @@ jobs:
           name: install dependencies
           command: |
             bundle install
-       # build the jekyll site
-       - run:
+ 
+      # build the jekyll site
+      - run:
           name: build the site
           command: |
             bundle exec jekyll build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
     branches:
       only:
         - master
+        - develop
 
     docker:
       # specify the version you desire here
@@ -28,6 +29,11 @@ jobs:
           name: install dependencies
           command: |
             bundle install
+       # build the jekyll site
+       - run:
+          name: build the site
+          command: |
+            bundle exec jekyll build
 
       # Download and cache dependencies
       - restore_cache:


### PR DESCRIPTION
Builds the jekyll site as part of the circleci process to allow for ignoring the _site folder.
Also builds on commit to develop to allow for earlier running of tests.